### PR TITLE
Prepare bill of materials

### DIFF
--- a/outpostcli/cli.py
+++ b/outpostcli/cli.py
@@ -85,3 +85,19 @@ def normalise(yaml_specification):
     yaml_structure = materials.expand(yaml_specification)
     normalised_yaml_string = materials.condense(yaml_structure)
     click.echo(normalised_yaml_string)
+
+@outpost.command()
+@click.argument('yaml_specification', type=click.File('rb'), required=False)
+def bom(yaml_specification):
+    """Produce a bill of materials (BOM) from an outpost spec.
+
+    YAML_SPECIFICATION is the filename to read the specification from.
+    If this is not provided, the specification will be read from STDIN.
+    """
+    if yaml_specification is None:
+        input_stream = click.get_text_stream('stdin')
+        yaml_specification = input_stream.read()
+    materials.load_default()
+    yaml_structure = materials.expand(yaml_specification)
+    bom_yaml = materials.bom(yaml_structure)
+    click.echo(bom_yaml)

--- a/outpostcli/cli.py
+++ b/outpostcli/cli.py
@@ -93,11 +93,16 @@ def bom(yaml_specification):
 
     YAML_SPECIFICATION is the filename to read the specification from.
     If this is not provided, the specification will be read from STDIN.
+
+    Output is a Markdown list of Material:Quantity entries.
     """
     if yaml_specification is None:
         input_stream = click.get_text_stream('stdin')
         yaml_specification = input_stream.read()
     materials.load_default()
     yaml_structure = materials.expand(yaml_specification)
-    bom_yaml = materials.bom(yaml_structure)
-    click.echo(bom_yaml)
+    bom_structure = materials.bom(yaml_structure)
+    bom_markdown_items = [F'- {item}: {count}' for (item, count) in bom_structure.items()]
+    bom_markdown = "\n".join(bom_markdown_items)
+    click.echo("Bill of Materials:")
+    click.echo(bom_markdown)

--- a/outpostcli/materials.py
+++ b/outpostcli/materials.py
@@ -8,6 +8,7 @@ Provides an interface to the Starfield materials database.
 """
 
 import os
+import click
 import yaml
 
 materials_content = None # pylint: disable=C0103
@@ -51,13 +52,14 @@ def expand(yaml_string):
             item_name = item
             item_count = 1
         if item_name not in materials_dict:
+            click.echo(F'Item {item_name} was not found in materials database', err=True)
             continue
         item_materials = materials_dict[item_name]
         item_materials['count'] = item_count
         expanded_structure.append(item_materials)
     return expanded_structure
 
-def condense(yaml_structure):
+def condense(yaml_structure) -> str:
     """
     Given a data structure, produce a normalised YAML outpost specification.
     """
@@ -73,7 +75,7 @@ def condense(yaml_structure):
     yaml_text = yaml.dump(normalised_structure)
     return yaml_text
 
-def bom(yaml_structure):
+def bom(yaml_structure) -> dict:
     """
     Given a data structure, produce a Bill of Materials (BOM) listing the
     first-level expansion of the materials required to build the specified
@@ -92,5 +94,4 @@ def bom(yaml_structure):
                     bom_dict[material] = 0
                 material_quantity = materials[material] * item_count
                 bom_dict[material] += material_quantity
-    bom_yaml = yaml.dump(bom_dict)
-    return bom_yaml
+    return bom_dict

--- a/outpostcli/materials.py
+++ b/outpostcli/materials.py
@@ -81,11 +81,16 @@ def bom(yaml_structure):
     """
     bom_dict = {}
     for entry in yaml_structure:
+        if 'count' in entry:
+            item_count = entry['count']
+        else:
+            item_count = 1
         if 'materials' in entry:
             materials = entry['materials']
             for material in materials.keys():
                 if material not in bom_dict:
                     bom_dict[material] = 0
-                bom_dict[material] += materials[material]
+                material_quantity = materials[material] * item_count
+                bom_dict[material] += material_quantity
     bom_yaml = yaml.dump(bom_dict)
     return bom_yaml

--- a/outpostcli/materials.py
+++ b/outpostcli/materials.py
@@ -72,3 +72,20 @@ def condense(yaml_structure):
         normalised_structure.append(normalised_entry)
     yaml_text = yaml.dump(normalised_structure)
     return yaml_text
+
+def bom(yaml_structure):
+    """
+    Given a data structure, produce a Bill of Materials (BOM) listing the
+    first-level expansion of the materials required to build the specified
+    outpost.
+    """
+    bom_dict = {}
+    for entry in yaml_structure:
+        if 'materials' in entry:
+            materials = entry['materials']
+            for material in materials.keys():
+                if material not in bom_dict:
+                    bom_dict[material] = 0
+                bom_dict[material] += materials[material]
+    bom_yaml = yaml.dump(bom_dict)
+    return bom_yaml

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ import pytest, unittest
 # To learn more about testing Click applications, visit the link below.
 # http://click.pocoo.org/5/testing/
 
-class DescribeOutpostCommand(unittest.TestCase):
+class TestOutpostCommand(unittest.TestCase):
 	def test_displays_library_version_when_called_with_version_option(self):
 		runner: CliRunner = CliRunner()
 		result: Result = runner.invoke(cli.outpost, ["version"])
@@ -25,9 +25,14 @@ class DescribeOutpostCommand(unittest.TestCase):
 		), "Version number should match library version."
 
 
-	def test_normalise_output(self):
+	def test_normalises_output_to_outpost_specification(self):
 		runner: CliRunner = CliRunner()
 		result: Result = runner.invoke(cli.outpost, ["normalise", "tests/sample_spec.yml"])
 		assert (
 			"- Landing Pad - Small" in result.output.strip()
 		), "Verbose logging should be indicated in output."
+
+	def test_produces_a_bill_of_materials(self):
+		runner: CliRunner = CliRunner()
+		result: Result = runner.invoke(cli.outpost, ["bom", "tests/sample_spec.yml"])
+		assert ("Isocentered Magnet: 2" in result.output.strip()), "Output should contain appropriate quantity of Isocentered Magnets"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,4 +35,4 @@ class TestOutpostCommand(unittest.TestCase):
 	def test_produces_a_bill_of_materials(self):
 		runner: CliRunner = CliRunner()
 		result: Result = runner.invoke(cli.outpost, ["bom", "tests/sample_spec.yml"])
-		assert ("Isocentered Magnet: 2" in result.output.strip()), "Output should contain appropriate quantity of Isocentered Magnets"
+		assert ("Isocentered Magnet: 4" in result.output.strip()), "Output should contain appropriate quantity of Isocentered Magnets"


### PR DESCRIPTION
Given an outpost spec `procyon-iii.yml`:

```
- Landing Pad - Small
- Industrial Workbench
- Wind Turbine - Advanced: 3
- Extractor - Copper
- Storage - Solid - Large
- Extractor - Fluorine
- Storage - Gas - Large
- Extractor - Ionic Liquid
- Storage - Liquid - Large
```

This can be processed with the `outpost` command to produce a bill of materials:

```
$ outpost bom procyon-iii.yml
- Adaptive Frame: 30
- Aluminum: 77
- Copper: 23
- Iron: 51
- Isocentered Magnet: 6
- Nickel: 24
- Tungsten: 18
```